### PR TITLE
Update minimum value pointer when child is cut.

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,6 +144,9 @@ FibonacciHeap.prototype = {
       parent.removeChild(node);
       node.parent = null;
       this._rootList.push(node);
+      if (node.priority < this._min.priority) {
+        this._min = node;
+      }
       var key = stringify(node.value);
       this._mark[key] = false;
 

--- a/test/unit/update_test.js
+++ b/test/unit/update_test.js
@@ -67,6 +67,12 @@ suite('FibonacciHeap#update', function() {
     }), true);
   });
 
+  test('should update minimum immediately if child cut', function() {
+    subject.update({ value: 4, priority: 0 });
+    var min = subject.deleteMin();
+    assert.equal(min.value, 4);
+  });
+
   test('should mark parent when child cut', function() {
     subject.update({ value: 4, priority: 0 });
     assert.equal(subject.any(function(node) {


### PR DESCRIPTION
If a node's priority is updated in a way that violates heap-ordering, the node is cut from its current location to the root. Unless the _min pointer is also updated at this point, the next call to deleteMin() will not return the correct result. This commit hopefully fixes that; I'm not sure if anything else is at issue, but this fixes the problem I've been having at least :)
